### PR TITLE
Add option to set transaction timeout

### DIFF
--- a/foundationdb/store.go
+++ b/foundationdb/store.go
@@ -47,6 +47,13 @@ func New(mo store.MergeOperator, config map[string]interface{}) (store.KVStore, 
 		return nil, err
 	}
 
+	if timeout, exists := config["transactionTimeout"]; exists {
+		err = db.Options().SetTransactionTimeout(timeout.(int64))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// get foundationdb config
 	var sub subspace.Subspace
 	var pl int


### PR DESCRIPTION
It's a good idea to enable setting the transaction timeout option.
If it's not set the operation will block indefinitely in case of connection errors.
See docs here: https://apple.github.io/foundationdb/class-scheduling-go.html#transactions